### PR TITLE
Dummy functions and macros for ExDocs

### DIFF
--- a/lib/ex_spirit/parser.ex
+++ b/lib/ex_spirit/parser.ex
@@ -867,6 +867,109 @@ defmodule ExSpirit.Parser do
     end
   end
 
+  @doc """
+  """
+  defmacro parse(rest, parser, opts \\ []), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro valid_context?(context_ast), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro valid_context_matcher(), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro skip(context_ast), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro seq(context_ast, sequence), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro alt(context_ast, alternatives), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro tag(context_ast, tag_ast, parser_ast), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro no_skip(context_ast, parser_ast), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro skipper(context_ast, parser_ast, skipper_ast), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro ignore(context_ast, parser_ast, opts \\ []), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro branch(context_ast, parser_ast, symbol_map_ast), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro expect(context_ast, parser_ast), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro repeat(context_ast, parser_ast, minimum \\ 0, maximum \\ -1), do: raise "Ooops."
+
+  @doc """
+  """
+  def repeatFn(context, parser, minimum \\ 0, maximum \\ -1), do: raise "Ooops."
+
+  @doc """
+  """
+  def success(context, value \\ nil), do: raise "Ooops."
+
+  @doc """
+  """
+  def fail(context, reason \\ nil), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro pipe_context_into(context_ast, mapper_ast), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro pipe_result_into(context_ast, mapper_ast), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro pipe_context_around(context_ast, mapper_ast, parser_ast), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro put_state(context_ast, key, from), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro push_state(context_ast, key, from), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro get_state_into(context_ast, key, into), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro lookahead(context_ast, parser_ast), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro lookahead_not(context_ast, parser_ast), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro lexeme(context_ast, parser_ast), do: raise "Ooops."
+
+  @doc """
+  """
+  defmacro eoi(context_ast, opts \\ []), do: raise "Ooops."
 
   defmacro __using__(opts) do
     text_use_ast = if(opts[:text], do: quote(do: use ExSpirit.Parser.Text), else: nil)

--- a/lib/ex_spirit/parser.ex
+++ b/lib/ex_spirit/parser.ex
@@ -1,731 +1,39 @@
 defmodule ExSpirit.Parser do
   @moduledoc """
 
-  ExSpirit.Parser is the parsing section of ExSpirit, designed to parse out some
+  `ExSpirit.Parser` is the parsing section of ExSpirit, designed to parse out some
   kind of stream of data (whether via a binary, a list, or perhaps an actual
   stream) into a data structure of your own design.
 
 
-  # Definitions
+  ## Definitions
 
-  ## Terminal Parser
+  - **Terminal Parser**:
+    A terminal parser is one that does not operate over any other parser, it is
+    'terminal' in its location.
 
-  A terminal parser is one that does not operate over any other parser, it is
-  'terminal' in its location.
+  - **Combination Parser**:
+    A combination parser is one that takes a parser as an input and does something
+    with it, whether that is repeating it, surrounding it, or ignoring its output
+    as a few examples.
 
-  ## Combination Parser
-
-  A combination parser is one that takes a parser as an input and does something
-  with it, whether that is repeating it, surrounding it, or ignoring its output
-  as a few examples.
-
-
-  # Usage
+  ## Usage
 
   Just add `use ExSpirit.Parser` to a module to make it into a parsing module.
 
   To add text parsing functions from the `ExSpirit.Parsing.Text` module then add
-  `text: true` to the use call.
+  `text: true` to the use call. For example:
 
-  ### Example
-
-  ```elixir
-
-    defmodule MyModule do
-      use ExSpirit.Parser, text: true
-    end
-
-  ```
-
-  ## parse
-
-  The parse function is applied to the input and a parser call, such as in:
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("42", uint())
-    iex> {context.error, context.result, context.rest}
-    {nil, 42, ""}
-
-  ```
-
-  ## Skippers
-
-  A skipper is a parser that is passed to the `:skipper` key in the `parse` call
-  that will be called at the start of every built-in terminal.  So when you
-  parse a, for example, `uint()`, then it will be like calling
-  `(skipper |> uint())` in its place.  There are a few related function as well.
-
-  ### Examples
-
-  ```elixir
-
-    # A skipper runs only once per terminal, if you want it to repeat the skipper
-    # then set the skipper up so it repeats, a good one is `repeat(lit(?\\s))` for
-    # example
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse(" 42 ", uint(), skipper: lit(?\\s))
-    iex> {context.error, context.result, context.rest}
-    {nil, 42, " "}
-
-  ```
-
-
-  # Parsers
-
-  ## Elixir Standard Pipe Operator |>
-
-  The `|>` pipe operator can be used to run a parser, and then another parser,
-  however it will only return the result of the last parser in the pipe chain.
-
-  This library does *not* override Elixir's pipe operator, it uses it verbatum.
-  Use `seq` for the usual expected sequence parsing.
-
-  ### Examples
-
-  ```elixir
-
-    # `|>` Returns the result of the last parser in the pipe chain,
-    # `lit` always returns nil for example
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("42Test", uint() |> lit("Test"))
-    iex> {context.error, context.result, context.rest}
-    {nil, nil, ""}
-
-    # `|>` Returns the result of the last parser in the pipe chain
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("42Test64", uint() |> lit("Test") |> uint())
-    iex> {context.error, context.result, context.rest}
-    {nil, 64, ""}
-
-  ```
-
-  ## seq
-
-  The Sequence operator runs all of the parsers in the inline list (cannot be a
-  variable) and returns their results as a list.  Any `nil`'s returned are not
-  added to the result list, and if the result list has only a single value
-  returned then it returns that value straight away without being wrapped in a
-  list.
-
-  ### Examples
-
-  ```elixir
-
-    # `seq` parses a sequence returning the return of all of them, removing nils,
-    # as a list if more than one or the raw value if only one, if any fail then
-    # all fail.
-    iex> import ExSpirit.Tests.Parser
-    iex> contexts = parse("42 64", seq([uint(), lit(" "), uint()]))
-    iex> {contexts.error, contexts.result, contexts.rest}
-    {nil, [42, 64], ""}
-
-    # `seq` Here is sequence only returning a single value
-    iex> import ExSpirit.Tests.Parser
-    iex> contexts = parse("42Test", seq([uint(), lit("Test")]))
-    iex> {contexts.error, contexts.result, contexts.rest}
-    {nil, 42, ""}
-
-  ```
-
-  ## alt
-
-  The alternative parser runs the parsers in the inline list (cannot be a
-  variable) and returns the result of the first one that succeeds, or the error
-  of the last one.
-
-  ### Examples
-
-  ```elixir
-
-    # `alt` parses a set of alternatives in order and returns the first success
-    iex> import ExSpirit.Tests.Parser
-    iex> contexts = parse("FF", alt([uint(16), lit("Test")]))
-    iex> {contexts.error, contexts.result, contexts.rest}
-    {nil, 255, ""}
-
-    # `alt` parses a set of alternatives in order and returns the first success
-    iex> import ExSpirit.Tests.Parser
-    iex> contexts = parse("Test", alt([uint(16), lit("Test")]))
-    iex> {contexts.error, contexts.result, contexts.rest}
-    {nil, nil, ""}
-
-  ```
-
-  ## defrule
-
-  Defining a rule defines a parser as well as some associated information such
-  as the name of it for error reporting purposes, a mapping function so you can
-  convert the output on the fly (fantastic for in-line AST generation for
-  example!), among other uses.  It is used like any other normal terminal rule.
-
-  ### Examples
-
-  All of the following examples use this definition of rules in a module:
-
-  ```elixir
-
-    defmodule ExSpirit.Tests.Parser do
-      use ExSpirit.Parser, text: true
-
-      defrule testrule(
-        seq([ uint(), lit(?\s), uint() ])
-        )
-
-      defrule testrule_pipe(
-        seq([ uint(), lit(?\s), uint() ])
-        ), pipe_result_into: Enum.map(fn i -> i-40 end)
-
-      defrule testrule_fun(
-        seq([ uint(), lit(?\s), uint() ])
-        ), fun: (fn context -> %{context | result: {"altered", context.result}} end).()
-
-      defrule testrule_context(context) do
-        %{context | result: "always success"}
+      defmodule MyModule do
+        use ExSpirit.Parser, text: true
       end
 
-      defrule testrule_context_arg(context, value) do
-        %{context | result: value}
-      end
-    end
-
-  ```
-
-  ```elixir
-
-    # You can use `defrule`s as any other terminal parser
-    iex> import ExSpirit.Tests.Parser
-    iex> contexts = parse("42 64", testrule())
-    iex> {contexts.error, contexts.result, contexts.rest}
-    {nil, [42, 64], ""}
-
-    # `defrule`'s also set up a stack of calls down a context so you know
-    # 'where' an error occured, so name the rules descriptively
-    iex> import ExSpirit.Tests.Parser
-    iex> contexts = parse("42 fail", testrule())
-    iex> {contexts.error.context.rulestack, contexts.result, contexts.rest}
-    {[:testrule], nil, "fail"}
-
-    # `defrule`s can map the result to return a different one:
-    iex> import ExSpirit.Tests.Parser
-    iex> contexts = parse("42 64", testrule_pipe())
-    iex> {contexts.error, contexts.result, contexts.rest}
-    {nil, [2, 24], ""}
-
-    # `defrule`s can also operate over the context itself to do anything
-    iex> import ExSpirit.Tests.Parser
-    iex> contexts = parse("42 64", testrule_fun())
-    iex> {contexts.error, contexts.result, contexts.rest}
-    {nil, {"altered", [42, 64]}, ""}
-
-    # `defrule`s can also be a context function by only passing in `context`
-    iex> import ExSpirit.Tests.Parser
-    iex> contexts = parse("42 64", testrule_context())
-    iex> {contexts.error, contexts.result, contexts.rest}
-    {nil, "always success", "42 64"}
-
-    # `defrule`s with a context can have other arguments too, but context
-    # must always be first
-    iex> import ExSpirit.Tests.Parser
-    iex> contexts = parse("42 64", testrule_context_arg(:success))
-    iex> {contexts.error, contexts.result, contexts.rest}
-    {nil, :success, "42 64"}
-
-  ```
-
-  ## no_skip
-
-  The `no_skip` combination parser takes a parser and clears the skipper so they
-  do no skipping.  Good to parse non-skippable content within a large parser.
-
-  ### Examples
-
-  ```elixir
-
-    # You can turn off a skipper for a parser with `no_skip`
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse(" Test:42 ", lit("Test:") |> no_skip(uint()), skipper: lit(?\\s))
-    iex> {context.error, context.result, context.rest}
-    {nil, 42, " "}
-
-  ```
-
-  ## skipper
-
-  The `skipper` combination parser takes a parser and changes the skipper within
-  it to the one you pass in for the duration of the parser that you pass in.
-
-  ### Examples
-
-  ```elixir
-
-    # You can change a skipper for a parser as well with `skipper`
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse(" Test:\t42 ", lit("Test:") |> skipper(uint(), lit(?\\t)), skipper: lit(?\\s))
-    iex> {context.error, context.result, context.rest}
-    {nil, 42, " "}
-
-  ```
-
-  ## ignore
-
-  The `ignore` combination parser takes and runs a parser but ignores the
-  result of the parser, instead returning `nil`.
-  Can give the option of `pass_result: true` to pass the previous result on.
-
-  ### Examples
-
-  ```elixir
-
-    # `ignore` will run the parser but return no result
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("Test", ignore(char([?a..?z, ?T])))
-    iex> {context.error, context.result, context.rest}
-    {nil, nil, "est"}
-
-    # `ignore` will pass on the previous result if you want it to
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("42Test", uint() |> ignore(char([?a..?z, ?T]), pass_result: true))
-    iex> {context.error, context.result, context.rest}
-    {nil, 42, "est"}
-
-  ```
-
-  ## branch
-
-  The `branch` combination parser is designed for efficient branching based on
-  the result from another parser.  It allows you to parse something, and using
-  the result of that parser you can then either lookup the value in a map or
-  call into a user function, either of which can return a parser function that
-  will then be used to continue parsing.
-
-  It takes two arguments, the first of which is the initial parser, the second
-  is either a user function of `value -> parserFn` or a map of
-  `values => parserFn` where the value key is looked up from the result of the
-  first parser.  If the parserFn is `nil` then `branch` fails, else the parserFn
-  is executed to continue parsing.  Because of the anonymous function calls this
-  has a slight overhead so only use this if switching parsers dynamically based
-  on a parsed value that is more complex then a simple `alt` parser or the count
-  is more than a few branches in size.
-
-  This returns only the output from the parser in the map, not the lookup
-  parser.
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> symbol_map = %{?b => &uint(&1, 2), ?d => &uint(&1, 10), ?x => &uint(&1, 16)}
-    iex> context = parse("b101010", branch(char(), symbol_map))
-    iex> {context.error, context.result, context.rest}
-    {nil, 42, ""}
-    iex> context = parse("d213478", branch(char(), symbol_map))
-    iex> {context.error, context.result, context.rest}
-    {nil, 213478, ""}
-    iex> context = parse("xe1DCf", branch(char(), symbol_map))
-    iex> {context.error, context.result, context.rest}
-    {nil, 925135, ""}
-    iex> context = parse("a", branch(char(), symbol_map))
-    iex> {context.error.message, context.result, context.rest}
-    {"Tried to branch to `97` but it was not found in the symbol_map", nil, ""}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> symbol_mapper = fn
-    iex>   ?b -> &uint(&1, 2)
-    iex>   ?d -> &uint(&1, 10)
-    iex>   ?x -> &uint(&1, 16)
-    iex>   _value -> nil # Always have a default case.  :-)
-    iex> end
-    iex> context = parse("b101010", branch(char(), symbol_mapper))
-    iex> {context.error, context.result, context.rest}
-    {nil, 42, ""}
-    iex> context = parse("d213478", branch(char(), symbol_mapper))
-    iex> {context.error, context.result, context.rest}
-    {nil, 213478, ""}
-    iex> context = parse("xe1DCf", branch(char(), symbol_mapper))
-    iex> {context.error, context.result, context.rest}
-    {nil, 925135, ""}
-    iex> context = parse("a", branch(char(), symbol_mapper))
-    iex> {context.error.message, context.result, context.rest}
-    {"Tried to branch to `97` but it was not found in the symbol_map", nil, ""}
-
-  ```
-
-  ## tag
-
-  The tagger combination parser will wrap the result of the passed in parser in
-  a standard erlang 2-tuple, the first element is the tag that you pass in, the
-  second is the result of the parser.
-
-  ### Examples
-
-  ```elixir
-
-    # `tag` can tag the output from a parser
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("ff", tag(:integer, uint(16)))
-    iex> {context.error, context.result, context.rest}
-    {nil, {:integer, 255}, ""}
-
-  ```
-
-  ### Expect
-
-  The expectation parser takes a parser but if it fails then it returns a hard
-  error that will prevent further parsers, even in branch tests, from running.
-  The purpose of this parser is to hard mention parsing errors at the correct
-  parsing site, so that if you are parsing an `alt` of parsers, but you parse
-  out a 'let' for example, followed by an identifier, if the identifier fails
-  then you do not want to let the alt try the next one but instead fail out hard
-  with an error message related to the proper place the parse failed instead of
-  trying other parsers that you know will not succeed anyway.
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("do 10", lit("do ") |> expect(uint()))
-    iex> {context.error, context.result, context.rest}
-    {nil, 10, ""}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("do nope", lit("do ") |> expect(uint()))
-    iex> %ExSpirit.Parser.ExpectationFailureException{} = context.error
-    iex> {context.error.message, context.result, context.rest}
-    {"Parsing uint with radix of 10 had 0 digits but 1 minimum digits were required", nil, "nope"}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("do nope", alt([ lit("do ") |> expect(uint()), lit("blah") ]))
-    iex> %ExSpirit.Parser.ExpectationFailureException{} = context.error
-    iex> {context.error.message, context.result, context.rest}
-    {"Parsing uint with radix of 10 had 0 digits but 1 minimum digits were required", nil, "nope"}
-
-    # Difference without the `expect`
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("do nope", alt([ lit("do ") |> uint(), lit("blah") ]))
-    iex> %ExSpirit.Parser.ParseException{} = context.error
-    iex> {context.error.message, context.result, context.rest}
-    {"literal `blah` did not match the input", nil, "do nope"}
-
-  ```
-
-  ## repeat
-
-  The repeat parser repeats over a parser for bounded number of times, returning
-  the results as a list.  It does have a slight overhead compared to known
-  execution times due to an anonmous function call, but that is necessary when
-  performing a dynamic number of repetitions without mutable variables.
-
-  The optional arguments are the minimum number of repeats required, default of
-  0, and the maximum number of repeats, default of -1 (infinite).
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("TTTX", repeat(char(?T)))
-    iex> {context.error, context.result, context.rest}
-    {nil, [?T, ?T, ?T], "X"}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("TTTX", repeat(char(?T), 1))
-    iex> {context.error, context.result, context.rest}
-    {nil, [?T, ?T, ?T], "X"}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("TTTX", repeat(char(?T), 1, 10))
-    iex> {context.error, context.result, context.rest}
-    {nil, [?T, ?T, ?T], "X"}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("TTTX", repeat(char(?T), 1, 2))
-    iex> {context.error, context.result, context.rest}
-    {nil, [?T, ?T], "TX"}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("TTTX", repeat(char(?T), 4))
-    iex> {context.error.message, context.result, context.rest}
-    {"Repeating over a parser failed due to not reaching the minimum amount of 4 with only a repeat count of 3", nil, "X"}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("TTT", repeat(char(?T), 4))
-    iex> {context.error.message, context.result, context.rest}
-    {"Repeating over a parser failed due to not reaching the minimum amount of 4 with only a repeat count of 3", nil, ""}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("", repeat(char(?T)))
-    iex> {context.error, context.result, context.rest}
-    {nil, [], ""}
-
-  ```
-
-  ## repeatFn
-
-  The repeat function parser allows you to pass in a parser function to repeat
-  over, but is otherwise identical to `repeat`, especially as `repeat` delegates
-  to `repeatFn`.
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("TTTX", repeatFn(fn c -> c |> char(?T) end))
-    iex> {context.error, context.result, context.rest}
-    {nil, [?T, ?T, ?T], "X"}
-
-    # See `repeat` for more.
-
-  ```
-
-  ## success
-
-  The success parser always returns the passed in value, default of nil,
-  successfully like a parsed value.
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("", success(42))
-    iex> {context.error, context.result, context.rest}
-    {nil, 42, ""}
-
-  ```
-
-  ## fail
-
-  The fail parser always fails, documenting the user information passed in
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("", fail(42))
-    iex> {context.error.extradata, context.result, context.rest}
-    {42, nil, ""}
-
-  ```
-
-  ## pipe_context_into
-
-  Runs a function with the context
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> fun = fn c -> %{c|result: 42} end
-    iex> context = parse("a", pipe_context_into(fun.()))
-    iex> {context.error, context.result, context.rest}
-    {nil, 42, "a"}
-
-  ```
-
-  ## pipe_result_into
-
-  Runs a function with the result
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> fun = fn nil -> 42 end
-    iex> context = parse("a", pipe_result_into(fun.()))
-    iex> {context.error, context.result, context.rest}
-    {nil, 42, "a"}
-
-  ```
-
-  ## pipe_context_around
-
-  Runs a function and parser with the both the context before and after the
-  function call.
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> fun = fn {pre, post} -> %{post|result: {pre, post}} end
-    iex> context = parse("42", pipe_context_around(fun.(), uint()))
-    iex> {pre, post} = context.result
-    iex> {context.error, pre.column, post.column, context.rest}
-    {nil, 1, 3, ""}
-
-  ```
-
-  ## skip
-
-  Runs the skipper now
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("  a", skip(), skipper: chars(?\\s, 0))
-    iex> {context.error, context.result, context.rest}
-    {nil, nil, "a"}
-
-  ```
-
-  ## put_state
-
-  Puts something into the state at the specified key
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("42", uint() |> put_state(:test, :result))
-    iex> {context.error, context.result, context.rest, context.state}
-    {nil, 42, "", %{test: 42}}
-
-  ```
-
-  ## push_state
-
-  Puts something into the state at the specified key
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("42", uint() |> push_state(:test, :result))
-    iex> {context.error, context.result, context.rest, context.state}
-    {nil, 42, "", %{test: [42]}}
-
-  ```
-
-  ## get_state_into
-
-  Get something(s) from the state and put it into the locations in the parser
-  that are marked with &1-* bindings
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("A:A", char() |> put_state(:test, :result) |> lit(?:) |> get_state_into([:test], char(&1)))
-    iex> {context.error, context.result, context.rest}
-    {nil, ?A, ""}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("A:B", char() |> put_state(:test, :result) |> lit(?:) |> get_state_into([:test], char(&1)))
-    iex> {String.starts_with?(context.error.message, "Tried parsing out any of the the characters of"), context.result, context.rest}
-    {true, nil, "B"}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("A:B", char() |> put_state(:test, :result) |> lit(?:) |> get_state_into(:test, :result))
-    iex> {context.error, context.result, context.rest}
-    {nil, ?A, "B"}
-
-  ```
-
-  ## lookahead
-
-  Looks ahead to confirm success, but does not update the context when
-  successful.
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("AA", lit(?A) |> lookahead(lit(?A)) |> char())
-    iex> {context.error, context.result, context.rest}
-    {nil, ?A, ""}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("AB", lit(?A) |> lookahead(lit(?A)) |> char())
-    iex> {String.starts_with?(context.error.message, "Lookahead failed"), context.result, context.rest}
-    {true, nil, "B"}
-
-  ```
-
-  ## lookahead_not
-
-  Looks ahead to confirm failure, but does not update the context when
-  failed.
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("AB", lit(?A) |> lookahead_not(lit(?A)) |> char())
-    iex> {context.error, context.result, context.rest}
-    {nil, ?B, ""}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("AA", lit(?A) |> lookahead_not(lit(?A)) |> char())
-    iex> {String.starts_with?(context.error.message, "Lookahead_not failed"), context.result, context.rest}
-    {true, nil, "A"}
-
-  ```
-
-  ## lexeme
-
-  Returns the entire parsed text from the parser, regardless of the actual
-  return value.
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("A256B", lexeme(char() |> uint()))
-    iex> {context.error, context.result, context.rest}
-    {nil, "A256", "B"}
-
-  ```
-
-  ## eoi
-
-  Success if there at the "End Of Input", else fails.
-  If the argument is statically `pass_result: true` then it passes on the prior
-  return value.
-  If the argument is statically `result: whatever` with `whatever` being what
-  you want to return, then it will set the result to that value on success.
-  `pass_result` must be set to false to use `result: value` or it is skipped.
-
-  ### Examples
-
-  ```elixir
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("42", uint() |> eoi())
-    iex> {context.error, context.result, context.rest}
-    {nil, nil, ""}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("42", uint() |> eoi(pass_result: true))
-    iex> {context.error, context.result, context.rest}
-    {nil, 42, ""}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("42", uint() |> eoi(result: :success))
-    iex> {context.error, context.result, context.rest}
-    {nil, :success, ""}
-
-    iex> import ExSpirit.Tests.Parser
-    iex> context = parse("42a", uint() |> eoi())
-    iex> {is_map(context.error), context.result, context.rest}
-    {true, nil, "a"}
-
-  ```
+  Note that the `ExSpirit.Parser` module must be `use`ed, and not `import`ed!
+  The functions and macros below are meant to be defined inside your own module
+  throught code generation orchestrated by the `__using__` macro.
+
+  Importing the module will not bring any useful functions or macros into your scope,
+  only "virtual" functions and macros that are used for documentation only.
   """
 
   defmodule Context do
@@ -742,6 +50,23 @@ defmodule ExSpirit.Parser do
       state: %{},
       userdata: nil
       )
+  end
+
+  defmodule ImportInsteadOfUseException do
+    defexception name: nil, kind: nil
+
+    def message(exc) do
+      """
+      You have tried to call the `#{exc.name}` #{exc.kind}.
+
+      You seem to have imported the `ExSpirit.Parser` module.
+      The `ExSpirit.Parser` module must be `use`d and not `import`ed.
+      Please add to your module:
+
+        `use ExSpirit.Parser` (or `use ExSpirit.Parser, text: true`) instead of
+        `import ExSpirit.Parser`
+      """
+    end
   end
 
   defmodule ParseException do
@@ -800,7 +125,82 @@ defmodule ExSpirit.Parser do
   end
 
 
+  @doc """
+  Defining a rule defines a parser as well as some associated information.
 
+  Such associated information can be the its name for error reporting purposes,
+  a mapping function so you can convert the output on the fly
+  (fantastic for in-line AST generation for example!), among others.
+
+  It is used like any other normal terminal rule.
+
+  All of the following examples use this definition of rules in a module:
+
+      defmodule ExSpirit.Tests.Parser do
+        use ExSpirit.Parser, text: true
+
+        defrule testrule(
+          seq([ uint(), lit(?\s), uint() ])
+          )
+
+        defrule testrule_pipe(
+          seq([ uint(), lit(?\s), uint() ])
+          ), pipe_result_into: Enum.map(fn i -> i-40 end)
+
+        defrule testrule_fun(
+          seq([ uint(), lit(?\s), uint() ])
+          ), fun: (fn context -> %{context | result: {"altered", context.result}} end).()
+
+        defrule testrule_context(context) do
+          %{context | result: "always success"}
+        end
+
+        defrule testrule_context_arg(context, value) do
+          %{context | result: value}
+        end
+      end
+
+
+    ## Examples
+
+      # You can use `defrule`s as any other terminal parser
+      iex> import ExSpirit.Tests.Parser
+      iex> contexts = parse("42 64", testrule())
+      iex> {contexts.error, contexts.result, contexts.rest}
+      {nil, [42, 64], ""}
+
+      # `defrule`'s also set up a stack of calls down a context so you know
+      # 'where' an error occured, so name the rules descriptively
+      iex> import ExSpirit.Tests.Parser
+      iex> contexts = parse("42 fail", testrule())
+      iex> {contexts.error.context.rulestack, contexts.result, contexts.rest}
+      {[:testrule], nil, "fail"}
+
+      # `defrule`s can map the result to return a different one:
+      iex> import ExSpirit.Tests.Parser
+      iex> contexts = parse("42 64", testrule_pipe())
+      iex> {contexts.error, contexts.result, contexts.rest}
+      {nil, [2, 24], ""}
+
+      # `defrule`s can also operate over the context itself to do anything
+      iex> import ExSpirit.Tests.Parser
+      iex> contexts = parse("42 64", testrule_fun())
+      iex> {contexts.error, contexts.result, contexts.rest}
+      {nil, {"altered", [42, 64]}, ""}
+
+      # `defrule`s can also be a context function by only passing in `context`
+      iex> import ExSpirit.Tests.Parser
+      iex> contexts = parse("42 64", testrule_context())
+      iex> {contexts.error, contexts.result, contexts.rest}
+      {nil, "always success", "42 64"}
+
+      # `defrule`s with a context can have other arguments too, but context
+      # must always be first
+      iex> import ExSpirit.Tests.Parser
+      iex> contexts = parse("42 64", testrule_context_arg(:success))
+      iex> {contexts.error, contexts.result, contexts.rest}
+      {nil, :success, "42 64"}
+  """
   defmacro defrule({name, _, [parser_ast]}) when is_atom(name), do: defrule_impl(name, parser_ast, [])
 
   defmacro defrule({name, _, [{:context, _, _} = context_ast | rest_args_ast]}, do: do_ast) when is_atom(name) do
@@ -868,108 +268,561 @@ defmodule ExSpirit.Parser do
   end
 
   @doc """
+  The parse function is applied to the input and a parser call, such as in:
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("42", uint())
+      iex> {context.error, context.result, context.rest}
+      {nil, 42, ""}
   """
-  defmacro parse(rest, parser, opts \\ []), do: raise "Ooops."
+  defmacro parse(rest, parser, opts \\ []) do
+    _ignore = {rest, parser, opts}
+    raise %ImportInsteadOfUseException{name: "parse", kind: "macro"}
+  end
 
   @doc """
+  Tests whether the context is valid.
   """
-  defmacro valid_context?(context_ast), do: raise "Ooops."
+  defmacro valid_context?(context_ast) do
+    _ignore = {context_ast}
+    raise %ImportInsteadOfUseException{name: "valid_context?", kind: "macro"}
+  end
+
+  @doc false
+  defmacro valid_context_matcher() do
+    _ignore = {}
+    raise %ImportInsteadOfUseException{name: "valid_context_matcher?", kind: "macro"}
+  end
 
   @doc """
+  Runs the skipper now
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("  a", skip(), skipper: chars(?\\s, 0))
+      iex> {context.error, context.result, context.rest}
+      {nil, nil, "a"}
   """
-  defmacro valid_context_matcher(), do: raise "Ooops."
+  defmacro skip(context_ast) do
+    _ignore = {context_ast}
+    raise %ImportInsteadOfUseException{name: "skip", kind: "macro"}
+  end
 
   @doc """
+  The Sequence operator runs all of the parsers in the inline list (cannot be a
+  variable) and returns their results as a list.
+
+  Any `nil`'s returned are not added to the result list, and if the result list
+  has only a single value returned then it returns that value straight away
+  without being wrapped in a list.
+
+  ## Examples
+      # `seq` parses a sequence returning the return of all of them, removing nils,
+      # as a list if more than one or the raw value if only one, if any fail then
+      # all fail.
+      iex> import ExSpirit.Tests.Parser
+      iex> contexts = parse("42 64", seq([uint(), lit(" "), uint()]))
+      iex> {contexts.error, contexts.result, contexts.rest}
+      {nil, [42, 64], ""}
+
+      # `seq` Here is sequence only returning a single value
+      iex> import ExSpirit.Tests.Parser
+      iex> contexts = parse("42Test", seq([uint(), lit("Test")]))
+      iex> {contexts.error, contexts.result, contexts.rest}
+      {nil, 42, ""}
   """
-  defmacro skip(context_ast), do: raise "Ooops."
+  defmacro seq(context_ast, sequence) do
+    _ignore = {context_ast, sequence}
+    raise %ImportInsteadOfUseException{name: "seq", kind: "macro"}
+  end
 
   @doc """
+  The alternative parser runs the parsers in the inline list (cannot be a
+  variable) and returns the result of the first one that succeeds, or the error
+  of the last one.
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> contexts = parse("FF", alt([uint(16), lit("Test")]))
+      iex> {contexts.error, contexts.result, contexts.rest}
+      {nil, 255, ""}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> contexts = parse("Test", alt([uint(16), lit("Test")]))
+      iex> {contexts.error, contexts.result, contexts.rest}
+      {nil, nil, ""}
+
   """
-  defmacro seq(context_ast, sequence), do: raise "Ooops."
+  defmacro alt(context_ast, alternatives) do
+    _ignore = {context_ast, alternatives}
+    raise %ImportInsteadOfUseException{name: "alt", kind: "macro"}
+  end
 
   @doc """
+  Wraps the result of the passed in parser in a standard erlang 2-tuple,
+  where the first element the tag that you pass in
+  and the second is the result of the parser.
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("ff", tag(:integer, uint(16)))
+      iex> {context.error, context.result, context.rest}
+      {nil, {:integer, 255}, ""}
   """
-  defmacro alt(context_ast, alternatives), do: raise "Ooops."
+  defmacro tag(context_ast, tag_ast, parser_ast) do
+    _ignore = {context_ast, tag_ast, parser_ast}
+    raise %ImportInsteadOfUseException{name: "tag", kind: "macro"}
+  end
 
   @doc """
+  The `no_skip` combination parser takes a parser and clears the skipper so they
+  do no skipping.
+
+  Good to parse non-skippable content within a large parser.
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse(" Test:42 ", lit("Test:") |> no_skip(uint()), skipper: lit(?\\s))
+      iex> {context.error, context.result, context.rest}
+      {nil, 42, " "}
   """
-  defmacro tag(context_ast, tag_ast, parser_ast), do: raise "Ooops."
+  defmacro no_skip(context_ast, parser_ast) do
+    _ignore = {context_ast, parser_ast}
+    raise %ImportInsteadOfUseException{name: "no_skip", kind: "macro"}
+  end
 
   @doc """
+  The `skipper` combination parser takes a parser and changes the skipper within
+  it to the one you pass in for the duration of the parser that you pass in.
+
+  ### Examples
+      # You can change a skipper for a parser as well with `skipper`
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse(" Test:\t42 ", lit("Test:") |> skipper(uint(), lit(?\\t)), skipper: lit(?\\s))
+      iex> {context.error, context.result, context.rest}
+      {nil, 42, " "}
   """
-  defmacro no_skip(context_ast, parser_ast), do: raise "Ooops."
+  defmacro skipper(context_ast, parser_ast, skipper_ast) do
+    _ignore = {context_ast, parser_ast, skipper_ast}
+    raise %ImportInsteadOfUseException{name: "skipper", kind: "macro"}
+  end
 
   @doc """
+  Takes and runs a parser but ignores the result of the parser, instead returning `nil`.
+
+  Can be given the option of `pass_result: true` to pass the previous result on.
+
+  ## Examples
+      # `ignore` will run the parser but return no result
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("Test", ignore(char([?a..?z, ?T])))
+      iex> {context.error, context.result, context.rest}
+      {nil, nil, "est"}
+
+      # `ignore` will pass on the previous result if you want it to
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("42Test", uint() |> ignore(char([?a..?z, ?T]), pass_result: true))
+      iex> {context.error, context.result, context.rest}
+      {nil, 42, "est"}
   """
-  defmacro skipper(context_ast, parser_ast, skipper_ast), do: raise "Ooops."
+  defmacro ignore(context_ast, parser_ast, opts \\ []) do
+    _ignore = {context_ast, parser_ast, opts}
+    raise %ImportInsteadOfUseException{name: "ignore", kind: "macro"}
+  end
 
   @doc """
+  The `branch` combination parser is designed for efficient branching based on
+  the result from another parser.
+
+  It allows you to parse something, and using the result of that parser
+  you can then either lookup the value in a map or call into a user function,
+  either of which can return a parser function that will then be used to continue parsing.
+
+  It takes two arguments, the first of which is the initial parser, the second
+  is either a user function of `value -> parserFn` or a map of
+  `values => parserFn` where the value key is looked up from the result of the
+  first parser.  If the parserFn is `nil` then `branch` fails, else the parserFn
+  is executed to continue parsing.  Because of the anonymous function calls this
+  has a slight overhead so only use this if switching parsers dynamically based
+  on a parsed value that is more complex then a simple `alt` parser or the count
+  is more than a few branches in size.
+
+  This returns only the output from the parser in the map, not the lookup
+  parser.
+
+  ### Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> symbol_map = %{?b => &uint(&1, 2), ?d => &uint(&1, 10), ?x => &uint(&1, 16)}
+      iex> context = parse("b101010", branch(char(), symbol_map))
+      iex> {context.error, context.result, context.rest}
+      {nil, 42, ""}
+      iex> context = parse("d213478", branch(char(), symbol_map))
+      iex> {context.error, context.result, context.rest}
+      {nil, 213478, ""}
+      iex> context = parse("xe1DCf", branch(char(), symbol_map))
+      iex> {context.error, context.result, context.rest}
+      {nil, 925135, ""}
+      iex> context = parse("a", branch(char(), symbol_map))
+      iex> {context.error.message, context.result, context.rest}
+      {"Tried to branch to `97` but it was not found in the symbol_map", nil, ""}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> symbol_mapper = fn
+      iex>   ?b -> &uint(&1, 2)
+      iex>   ?d -> &uint(&1, 10)
+      iex>   ?x -> &uint(&1, 16)
+      iex>   _value -> nil # Always have a default case.  :-)
+      iex> end
+      iex> context = parse("b101010", branch(char(), symbol_mapper))
+      iex> {context.error, context.result, context.rest}
+      {nil, 42, ""}
+      iex> context = parse("d213478", branch(char(), symbol_mapper))
+      iex> {context.error, context.result, context.rest}
+      {nil, 213478, ""}
+      iex> context = parse("xe1DCf", branch(char(), symbol_mapper))
+      iex> {context.error, context.result, context.rest}
+      {nil, 925135, ""}
+      iex> context = parse("a", branch(char(), symbol_mapper))
+      iex> {context.error.message, context.result, context.rest}
+      {"Tried to branch to `97` but it was not found in the symbol_map", nil, ""}
   """
-  defmacro ignore(context_ast, parser_ast, opts \\ []), do: raise "Ooops."
+  defmacro branch(context_ast, parser_ast, symbol_map_ast) do
+    _ignore = {context_ast, parser_ast, symbol_map_ast}
+    raise %ImportInsteadOfUseException{name: "branch", kind: "macro"}
+  end
 
   @doc """
+  Takes a parser but if it fails then it returns a hard error
+  that will prevent further parsers, even in branch tests, from running.
+
+  The purpose of this parser is to hard mention parsing errors at the correct
+  parsing site, so that if you are parsing an `alt` of parsers, but you parse
+  out a 'let' for example, followed by an identifier, if the identifier fails
+  then you do not want to let the alt try the next one but instead fail out hard
+  with an error message related to the proper place the parse failed instead of
+  trying other parsers that you know will not succeed anyway.
+
+  ### Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("do 10", lit("do ") |> expect(uint()))
+      iex> {context.error, context.result, context.rest}
+      {nil, 10, ""}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("do nope", lit("do ") |> expect(uint()))
+      iex> %ExSpirit.Parser.ExpectationFailureException{} = context.error
+      iex> {context.error.message, context.result, context.rest}
+      {"Parsing uint with radix of 10 had 0 digits but 1 minimum digits were required", nil, "nope"}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("do nope", alt([ lit("do ") |> expect(uint()), lit("blah") ]))
+      iex> %ExSpirit.Parser.ExpectationFailureException{} = context.error
+      iex> {context.error.message, context.result, context.rest}
+      {"Parsing uint with radix of 10 had 0 digits but 1 minimum digits were required", nil, "nope"}
+
+      # Difference without the `expect`
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("do nope", alt([ lit("do ") |> uint(), lit("blah") ]))
+      iex> %ExSpirit.Parser.ParseException{} = context.error
+      iex> {context.error.message, context.result, context.rest}
+      {"literal `blah` did not match the input", nil, "do nope"}
   """
-  defmacro branch(context_ast, parser_ast, symbol_map_ast), do: raise "Ooops."
+  defmacro expect(context_ast, parser_ast) do
+    _ignore = {context_ast, parser_ast}
+    raise %ImportInsteadOfUseException{name: "expect", kind: "macro"}
+  end
 
   @doc """
+  Repeats over a parser for bounded number of times, returning the results as a list.
+
+  It does have a slight overhead compared to known execution times
+  due to an anonmous function call, but that is necessary when
+  performing a dynamic number of repetitions without mutable variables.
+
+  The optional arguments are the minimum number of repeats required, default of
+  `0`, and the maximum number of repeats, default of `-1` (infinite).
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("TTTX", repeat(char(?T)))
+      iex> {context.error, context.result, context.rest}
+      {nil, [?T, ?T, ?T], "X"}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("TTTX", repeat(char(?T), 1))
+      iex> {context.error, context.result, context.rest}
+      {nil, [?T, ?T, ?T], "X"}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("TTTX", repeat(char(?T), 1, 10))
+      iex> {context.error, context.result, context.rest}
+      {nil, [?T, ?T, ?T], "X"}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("TTTX", repeat(char(?T), 1, 2))
+      iex> {context.error, context.result, context.rest}
+      {nil, [?T, ?T], "TX"}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("TTTX", repeat(char(?T), 4))
+      iex> {context.error.message, context.result, context.rest}
+      {"Repeating over a parser failed due to not reaching the minimum amount of 4 with only a repeat count of 3", nil, "X"}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("TTT", repeat(char(?T), 4))
+      iex> {context.error.message, context.result, context.rest}
+      {"Repeating over a parser failed due to not reaching the minimum amount of 4 with only a repeat count of 3", nil, ""}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("", repeat(char(?T)))
+      iex> {context.error, context.result, context.rest}
+      {nil, [], ""}
   """
-  defmacro expect(context_ast, parser_ast), do: raise "Ooops."
+  defmacro repeat(context_ast, parser_ast, minimum \\ 0, maximum \\ -1) do
+    _ignore = {context_ast, parser_ast, minimum, maximum}
+    raise %ImportInsteadOfUseException{name: "repeat", kind: "macro"}
+  end
 
   @doc """
+  The repeat function parser allows you to pass in a parser function to repeat
+  over, but is otherwise identical to `repeat`, especially as `repeat` delegates
+  to `repeatFn`.
+
+  See `ExSpirit.Parser.repeat/4` for more.
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("TTTX", repeatFn(fn c -> c |> char(?T) end))
+      iex> {context.error, context.result, context.rest}
+      {nil, [?T, ?T, ?T], "X"}
   """
-  defmacro repeat(context_ast, parser_ast, minimum \\ 0, maximum \\ -1), do: raise "Ooops."
+  def repeatFn(context, parser, minimum \\ 0, maximum \\ -1) do
+    _ignore = {context, parser, minimum, maximum}
+    raise %ImportInsteadOfUseException{name: "repeatFn", kind: "function"}
+  end
 
   @doc """
+  The success parser always returns the passed in value, default of nil,
+  successfully like a parsed value.
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("", success(42))
+      iex> {context.error, context.result, context.rest}
+      {nil, 42, ""}
   """
-  def repeatFn(context, parser, minimum \\ 0, maximum \\ -1), do: raise "Ooops."
+  def success(context, value \\ nil) do
+    _ignore = {context, value}
+    raise %ImportInsteadOfUseException{name: "success", kind: "function"}
+  end
 
   @doc """
+  The fail parser always fails, documenting the user information passed in
+
+  ## Examples
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("", fail(42))
+      iex> {context.error.extradata, context.result, context.rest}
+      {42, nil, ""}
   """
-  def success(context, value \\ nil), do: raise "Ooops."
+  def fail(context, reason \\ nil) do
+    _ignore = {context, reason}
+    raise %ImportInsteadOfUseException{name: "fail", kind: "function"}
+  end
 
   @doc """
+  Runs a function with the context.
+
+  TODO: Expand this *a lot*.
+
+  ### Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> fun = fn c -> %{c|result: 42} end
+      iex> context = parse("a", pipe_context_into(fun.()))
+      iex> {context.error, context.result, context.rest}
+      {nil, 42, "a"}
   """
-  def fail(context, reason \\ nil), do: raise "Ooops."
+  defmacro pipe_context_into(context_ast, mapper_ast) do
+    _ignore = {context_ast, mapper_ast}
+    raise %ImportInsteadOfUseException{name: "pipe_context_into", kind: "macro"}
+  end
 
   @doc """
+  Runs a function with the result
+
+  ### Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> fun = fn nil -> 42 end
+      iex> context = parse("a", pipe_result_into(fun.()))
+      iex> {context.error, context.result, context.rest}
+      {nil, 42, "a"}
   """
-  defmacro pipe_context_into(context_ast, mapper_ast), do: raise "Ooops."
+  defmacro pipe_result_into(context_ast, mapper_ast) do
+    _ignore = {context_ast, mapper_ast}
+    raise %ImportInsteadOfUseException{name: "pipe_result_into", kind: "macro"}
+  end
 
   @doc """
+  Runs a function and parser with the both the context before and after the
+  function call.
+
+  ### Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> fun = fn {pre, post} -> %{post|result: {pre, post}} end
+      iex> context = parse("42", pipe_context_around(fun.(), uint()))
+      iex> {pre, post} = context.result
+      iex> {context.error, pre.column, post.column, context.rest}
+      {nil, 1, 3, ""}
   """
-  defmacro pipe_result_into(context_ast, mapper_ast), do: raise "Ooops."
+  defmacro pipe_context_around(context_ast, mapper_ast, parser_ast) do
+    _ignore = {context_ast, mapper_ast, parser_ast}
+    raise %ImportInsteadOfUseException{name: "pipe_context_around", kind: "macro"}
+  end
 
   @doc """
+  Puts something into the state at the specified key
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("42", uint() |> put_state(:test, :result))
+      iex> {context.error, context.result, context.rest, context.state}
+      {nil, 42, "", %{test: 42}}
   """
-  defmacro pipe_context_around(context_ast, mapper_ast, parser_ast), do: raise "Ooops."
+  defmacro put_state(context_ast, key, from) do
+    _ignore = {context_ast, key, from}
+    raise %ImportInsteadOfUseException{name: "put_state", kind: "macro"}
+  end
 
   @doc """
+  Puts something into the state at the specified key
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("42", uint() |> push_state(:test, :result))
+      iex> {context.error, context.result, context.rest, context.state}
+      {nil, 42, "", %{test: [42]}}
   """
-  defmacro put_state(context_ast, key, from), do: raise "Ooops."
+  defmacro push_state(context_ast, key, from) do
+    _ignore = {context_ast, key, from}
+    raise %ImportInsteadOfUseException{name: "push_state", kind: "macro"}
+  end
 
   @doc """
+  Get something(s) from the state and put it into the locations in the parser
+  that are marked with &1-* bindings
+
+  ### Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("A:A", char() |> put_state(:test, :result) |> lit(?:) |> get_state_into([:test], char(&1)))
+      iex> {context.error, context.result, context.rest}
+      {nil, ?A, ""}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("A:B", char() |> put_state(:test, :result) |> lit(?:) |> get_state_into([:test], char(&1)))
+      iex> {String.starts_with?(context.error.message, "Tried parsing out any of the the characters of"), context.result, context.rest}
+      {true, nil, "B"}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("A:B", char() |> put_state(:test, :result) |> lit(?:) |> get_state_into(:test, :result))
+      iex> {context.error, context.result, context.rest}
+      {nil, ?A, "B"}
   """
-  defmacro push_state(context_ast, key, from), do: raise "Ooops."
+  defmacro get_state_into(context_ast, key, into) do
+    _ignore = {context_ast, key, into}
+    raise %ImportInsteadOfUseException{name: "get_state_into", kind: "macro"}
+  end
 
   @doc """
+  Looks ahead to confirm success, but does not update the context when
+  successful.
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("AA", lit(?A) |> lookahead(lit(?A)) |> char())
+      iex> {context.error, context.result, context.rest}
+      {nil, ?A, ""}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("AB", lit(?A) |> lookahead(lit(?A)) |> char())
+      iex> {String.starts_with?(context.error.message, "Lookahead failed"), context.result, context.rest}
+      {true, nil, "B"}
   """
-  defmacro get_state_into(context_ast, key, into), do: raise "Ooops."
+  defmacro lookahead(context_ast, parser_ast) do
+    _ignore = {context_ast, parser_ast}
+    raise %ImportInsteadOfUseException{name: "lookahead", kind: "macro"}
+  end
 
   @doc """
+  Looks ahead to confirm failure, but does not update the context when
+  failed.
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("AB", lit(?A) |> lookahead_not(lit(?A)) |> char())
+      iex> {context.error, context.result, context.rest}
+      {nil, ?B, ""}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("AA", lit(?A) |> lookahead_not(lit(?A)) |> char())
+      iex> {String.starts_with?(context.error.message, "Lookahead_not failed"), context.result, context.rest}
+      {true, nil, "A"}
   """
-  defmacro lookahead(context_ast, parser_ast), do: raise "Ooops."
+  defmacro lookahead_not(context_ast, parser_ast) do
+    _ignore = {context_ast, parser_ast}
+    raise %ImportInsteadOfUseException{name: "lookahead_not", kind: "macro"}
+  end
 
   @doc """
+  Returns the entire parsed text from the parser, regardless of the actual return value.
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("A256B", lexeme(char() |> uint()))
+      iex> {context.error, context.result, context.rest}
+      {nil, "A256", "B"}
   """
-  defmacro lookahead_not(context_ast, parser_ast), do: raise "Ooops."
+  defmacro lexeme(context_ast, parser_ast) do
+    _ignore = {context_ast, parser_ast}
+    raise %ImportInsteadOfUseException{name: "lexeme", kind: "macro"}
+  end
 
   @doc """
-  """
-  defmacro lexeme(context_ast, parser_ast), do: raise "Ooops."
+  Success if there at the "End Of Input", else fails.
 
-  @doc """
+  If the argument is statically `pass_result: true`
+  then it passes on the prior return value.
+
+  If the argument is statically `result: whatever` with `whatever` being what
+  you want to return, then it will set the result to that value on success.
+  `pass_result` must be set to false to use `result: value` or it is skipped.
+
+  ## Examples
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("42", uint() |> eoi())
+      iex> {context.error, context.result, context.rest}
+      {nil, nil, ""}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("42", uint() |> eoi(pass_result: true))
+      iex> {context.error, context.result, context.rest}
+      {nil, 42, ""}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("42", uint() |> eoi(result: :success))
+      iex> {context.error, context.result, context.rest}
+      {nil, :success, ""}
+
+      iex> import ExSpirit.Tests.Parser
+      iex> context = parse("42a", uint() |> eoi())
+      iex> {is_map(context.error), context.result, context.rest}
+      {true, nil, "a"}
   """
-  defmacro eoi(context_ast, opts \\ []), do: raise "Ooops."
+  defmacro eoi(context_ast, opts \\ []) do
+    _ignore = {context_ast, opts}
+    raise %ImportInsteadOfUseException{name: "eoi", kind: "macro"}
+  end
 
   defmacro __using__(opts) do
     text_use_ast = if(opts[:text], do: quote(do: use ExSpirit.Parser.Text), else: nil)

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule ExSpirit.Mixfile do
 
   defp deps do
     [
-      {:ex_doc, "~> 0.14.5", only: [:dev]},
+      {:ex_doc, "~> 0.17", only: [:dev]},
       {:cortex, "~> 0.2.0", only: [:dev, :test]}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{"cortex": {:hex, :cortex, "0.2.0", "014fcc76553508417c97203a6c1770adb36ae6446330ee05169869b5cd290cd7", [:mix], [{:exfswatch, "~> 0.4", [hex: :exfswatch, optional: false]}]},
-  "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.17.1", "39f777415e769992e6732d9589dc5846ea587f01412241f4a774664c746affbb", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "exfswatch": {:hex, :exfswatch, "0.4.2", "d88a63b5c2f8f040230d22010588ff73286fd1aef32564115afa3051eaa4391d", [:mix], []}}


### PR DESCRIPTION
Added some dummy functions and macros to get prettier and more useful ExDocs.
An error will be raised at compile-time (runtime) if any of the dummy macros (functions) is ever called.